### PR TITLE
[FIX] not historicized in deleting report

### DIFF
--- a/src/services/decision.js
+++ b/src/services/decision.js
@@ -142,8 +142,8 @@ function fromDeletingToResponse(deletingDecisions, loggedItems = []) {
       deleted: deletingDecisions[0].deleted,
       reason: deletingDecisions[0].reason,
       transaction_not_historicized: deletingDecisions.filter(({ action }) => {
-        const loggedItem = loggedItems.find(({ input }) => input === action) ?? { item: { delete: { error: "Something wrong with elasticsearch call" }}};
-        const error = loggedItem.item.delete.error;
+        const loggedItem = loggedItems.find(({ input }) => input === action) ?? { item: { index: { error: "Something wrong with elasticsearch call" }}};
+        const error = loggedItem.item.index.error;
         if (error) console.error(`${process.env.APP_ID}: Error while historicize decision ${JSON.stringify(error)}`);
         return !!error;
       }),


### PR DESCRIPTION
- Deleting a decision in elasticBulk result in a "delete" action.
- Add a "delete" action in transactional history result in an "index" action.
- Confusion caused a syntax error in building the response object.

Consequences:
- Response (and log) error even if deletion and indexing were done.